### PR TITLE
Create basic app framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Mater</title>
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+    <p>Soon this will be a working Pomodoro app. 🍅</p>
+  </body>
+
+  <script>
+    // You can also require other files to run in this process
+    require('./renderer.js')
+  </script>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,12 @@
+const electron = require('electron')
+const menubar = require('menubar')
+const mb = menubar({width: 220, height: 220})
+
+mb.on('ready', () => {
+  console.log('app is ready')
+  // your app code here
+})
+
+mb.on('after-create-window', () => {
+  mb.window.loadURL(`file://${__dirname}/index.html`)
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "mater",
+  "version": "0.1.0",
+  "description": "A Pomodoro menubar app",
+  "main": "index.js",
+  "scripts": {
+    "start": "electron main.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jasonlong/mater.git"
+  },
+  "keywords": [
+    "pomodoro",
+    "productivity",
+    "timer",
+    "electron",
+    "menubar"
+  ],
+  "author": "Jason Long",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jasonlong/mater/issues"
+  },
+  "homepage": "https://github.com/jasonlong/mater",
+  "dependencies": {
+    "menubar": "^5.1.0"
+  }
+}


### PR DESCRIPTION
Closes #1.

Having no idea what I was doing, I started with the [Electron site](http://electron.atom.io) and ended up looking at the quick-start project at https://github.com/electron/electron-quick-start. This helped me get Electron itself installed.

Then I took a peek at https://github.com/maxogden/menubar for the menubar module and the beginning of [this video](https://www.youtube.com/watch?v=jKzBJAowmGg) as a guide for what to do.

This is what it looks like now. Progress!

<img width="290" alt="screen shot 2016-11-09 at 1 16 36 pm" src="https://cloud.githubusercontent.com/assets/6104/20149908/46e1451e-a681-11e6-991f-c56cec7af69a.png">

The :cat2: icon is the default icon in the menubar module.