### PR TITLE
Show UI on timer stop

### DIFF
--- a/main.css
+++ b/main.css
@@ -25,10 +25,10 @@ body {
   left: 297px; /* (600 / 2 - half of width of start line) */
   width: 600px;
   text-align: left;
-  transition: 0.5s ease-in-out;
 }
 
 .slider.is-resetting {
+  transition: 0.5s ease-in-out;
   transform: translateX(-500px);
 }
 

--- a/main.js
+++ b/main.js
@@ -4,6 +4,11 @@ const mb = menubar({width: 220, height: 206, preloadWindow: true})
 
 require('electron-reload')(__dirname);
 
+// Make menubar accessible to the renderer
+global.sharedObject = {
+  mb: mb
+}
+
 mb.on('ready', () => {
   console.log('app is ready')
 })

--- a/renderer.js
+++ b/renderer.js
@@ -23,9 +23,11 @@ stopBtn.addEventListener('click', () => {
 })
 
 timer.on('tick', (ms) => {
-  slider.style.transform = 'translateX(-' + (500*ms)/(numMinutes*60*1000) + 'px)';
+  slider.classList.remove('is-resetting')
+  slider.style.transform = 'translateX(-' + Math.ceil((500*ms)/(numMinutes*60*1000)) + 'px)';
 })
 
 timer.on('done', () => {
+  appContainer.classList.remove('is-running')
   mb.showWindow()
 })

--- a/renderer.js
+++ b/renderer.js
@@ -1,3 +1,6 @@
+// Get menubar instance from main.js
+const mb = require('electron').remote.getGlobal('sharedObject').mb
+
 const Timer = require('tiny-timer')
 
 const appContainer = document.querySelector('.js-app-container')
@@ -23,4 +26,6 @@ timer.on('tick', (ms) => {
   slider.style.transform = 'translateX(-' + (500*ms)/(numMinutes*60*1000) + 'px)';
 })
 
-timer.on('done', () => console.log('done!'))
+timer.on('done', () => {
+  mb.showWindow()
+})


### PR DESCRIPTION
This makes the UI appear once the timer gets to zero. At this point, I feel like I can start actually using Mater since I have a way of being notified when the time is up.

I had to have access to the `menubar` instance in my renderer code, so I used the `sharedObject` method I came across on the Electron site. If anyone knows if this is a bad direction, please let me know.