### PR TITLE
Center button label on Windows

### DIFF
--- a/main.css
+++ b/main.css
@@ -149,6 +149,7 @@
   font-size: 1.125rem;
   font-weight: 500;
   color: #4e0300;
+  text-align: center;
   background-color: var(--white);
   border: 0;
   border-radius: 100px;


### PR DESCRIPTION
Fixes #30.

@streeetlamp Could you confirm that this change makes the button text centered on Windows?

Also, you should be able to toggle the web inspector with <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>I</kbd> or <kbd>F12</kbd>