### PR TITLE
Fix window position if taskbar on top

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 const {Menu} = require('electron')
 const menubar = require('menubar')
+const platform = require('os').platform()
 
 // Toggle with cmd + alt + i
 require('electron-debug')({showDevTools: true})
@@ -18,6 +19,12 @@ global.sharedObject = {mb}
 
 mb.on('ready', () => {
   console.log('app is ready')
+  // Workaround to fix window position when statusbar at top for win32
+  if (platform === 'win32') {
+    if (mb.tray.getBounds().y < 5) {
+      mb.setOption('windowPosition', 'trayCenter')
+    }
+  }
 })
 
 mb.on('after-create-window', () => {


### PR DESCRIPTION
Fixes #29 
Works on top
![2019-03-05_20-32-28](https://user-images.githubusercontent.com/5661040/53809013-56722700-3f86-11e9-81d3-2afa3368ec66.png)
Still works on bottom after quit and open app
![2019-03-05_20-33-53](https://user-images.githubusercontent.com/5661040/53809014-570abd80-3f86-11e9-8a5b-a09d25d898e8.png)
