### PR TITLE
Hide window with the esc key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mater",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A Pomodoro menubar app",
   "main": "main.js",
   "scripts": {

--- a/renderer.js
+++ b/renderer.js
@@ -84,6 +84,16 @@ setCurrentMinute(0)
 // Event handlers
 // =============================================================================
 
+document.addEventListener('keydown', event => {
+  switch (event.key) {
+    case 'Escape':
+      mb.hideWindow()
+      break
+    default:
+      break
+  }
+})
+
 startBtn.addEventListener('click', () => {
   playSound(soundWindup)
   timer.start(minToMs(workMinutes))
@@ -96,6 +106,10 @@ stopBtn.addEventListener('click', () => {
   playSound(soundClick)
   timer.stop()
   setState('stopped')
+})
+
+mb.on('after-hide', () => {
+  mb.app.hide()
 })
 
 timer.on('tick', ms => {


### PR DESCRIPTION
This addresses #130.

Currently, the menubar window appears when the timer hits zero and grabs the focus which can be disruptive to current work. I don't see a way to have the window appear and _not_ have focus, but this PR implements being able to hide the window when it appears with the <kbd>esc</kbd> key. This should also grant focus back to the window that had it before the timer ended.