### PR TITLE
Add deterministic timer scheduling

### DIFF
--- a/Mater/Model/TimerState.swift
+++ b/Mater/Model/TimerState.swift
@@ -8,6 +8,63 @@ enum TimerMode: Equatable {
     case breaking
 }
 
+@MainActor
+protocol TimerStateScheduledTask: AnyObject {
+    func cancel()
+}
+
+@MainActor
+protocol TimerStateScheduling: AnyObject {
+    var now: Date { get }
+
+    @discardableResult
+    func schedule(after interval: TimeInterval, _ action: @escaping @MainActor () -> Void) -> TimerStateScheduledTask
+
+    @discardableResult
+    func scheduleRepeating(every interval: TimeInterval, _ action: @escaping @MainActor () -> Void) -> TimerStateScheduledTask
+}
+
+@MainActor
+private final class ClosureTimerStateScheduledTask: TimerStateScheduledTask {
+    private var cancellation: (() -> Void)?
+
+    init(cancellation: @escaping () -> Void) {
+        self.cancellation = cancellation
+    }
+
+    func cancel() {
+        cancellation?()
+        cancellation = nil
+    }
+}
+
+final class SystemTimerStateScheduler: TimerStateScheduling {
+    var now: Date { Date() }
+
+    func schedule(after interval: TimeInterval, _ action: @escaping @MainActor () -> Void) -> TimerStateScheduledTask {
+        let workItem = DispatchWorkItem {
+            Task { @MainActor in
+                action()
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + interval, execute: workItem)
+        return ClosureTimerStateScheduledTask {
+            workItem.cancel()
+        }
+    }
+
+    func scheduleRepeating(every interval: TimeInterval, _ action: @escaping @MainActor () -> Void) -> TimerStateScheduledTask {
+        let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
+            Task { @MainActor in
+                action()
+            }
+        }
+        return ClosureTimerStateScheduledTask {
+            timer.invalidate()
+        }
+    }
+}
+
 @MainActor @Observable
 final class TimerState {
     static let pointsPerMinute: CGFloat = 20
@@ -38,8 +95,8 @@ final class TimerState {
     private(set) var windFromOffset: CGFloat = 0
     private(set) var windToOffset: CGFloat = 0
 
-    private var timer: Timer?
-    private var windCheckTimer: Timer?
+    private var timerTask: TimerStateScheduledTask?
+    private var windCheckTask: TimerStateScheduledTask?
     private var windupPlayer: AVAudioPlayer?
 
     private let dingSound: NSSound?
@@ -48,6 +105,7 @@ final class TimerState {
     private let tickSound: NSSound?
 
     let preferences: AppPreferences
+    private let scheduler: TimerStateScheduling
     private var workMinutes: Int { preferences.workMinutes }
     private var breakMinutes: Int { preferences.breakMinutes }
     private static let windSpeed: CGFloat = 500
@@ -57,8 +115,13 @@ final class TimerState {
     }
     private var maxWorkOffset: CGFloat { CGFloat(workMinutes) * Self.pointsPerMinute }
 
-    init(preferences: AppPreferences) {
+    convenience init(preferences: AppPreferences) {
+        self.init(preferences: preferences, scheduler: SystemTimerStateScheduler())
+    }
+
+    init(preferences: AppPreferences, scheduler: TimerStateScheduling) {
         self.preferences = preferences
+        self.scheduler = scheduler
         dingSound = Self.loadSound("ding")
         toggleOnSound = Self.loadSound("toggle_on")
         toggleOffSound = Self.loadSound("toggle_off")
@@ -91,7 +154,7 @@ final class TimerState {
         guard mode == .working || mode == .breaking,
               let startDate = cycleStartDate else { return }
 
-        let elapsed = Date().timeIntervalSince(startDate)
+        let elapsed = scheduler.now.timeIntervalSince(startDate)
         let remaining = cycleDuration - elapsed
 
         if remaining <= 0 {
@@ -126,7 +189,7 @@ final class TimerState {
             let minutes = minuteFromOffset(frozenSliderOffset)
             remainingSeconds = minutes * 60
         } else if mode == .working, let startDate = cycleStartDate {
-            let elapsed = Date().timeIntervalSince(startDate)
+            let elapsed = scheduler.now.timeIntervalSince(startDate)
             let newDuration = TimeInterval(newMax * 60)
             if elapsed >= newDuration {
                 stop()
@@ -185,14 +248,14 @@ final class TimerState {
             isMomentum = false
             momentumLastUpdate = nil
         } else if isWinding {
-            frozenSliderOffset = windingSliderOffset(at: Date())
+            frozenSliderOffset = windingSliderOffset(at: scheduler.now)
             cancelWind()
         } else if mode != .stopped {
-            frozenSliderOffset = continuousSliderOffset(at: Date())
+            frozenSliderOffset = continuousSliderOffset(at: scheduler.now)
         }
 
-        timer?.invalidate()
-        timer = nil
+        timerTask?.cancel()
+        timerTask = nil
         windupPlayer?.stop()
         cycleStartDate = nil
         cycleDuration = 0
@@ -224,7 +287,7 @@ final class TimerState {
         if abs(velocity) > 30 {
             isMomentum = true
             momentumVelocity = velocity
-            momentumLastUpdate = Date()
+            momentumLastUpdate = scheduler.now
             return
         }
 
@@ -295,7 +358,7 @@ final class TimerState {
         let seconds = minutes * 60
         mode = newMode
         cycleDuration = TimeInterval(seconds)
-        cycleStartDate = Date()
+        cycleStartDate = scheduler.now
         remainingSeconds = seconds
         startTimer()
     }
@@ -318,14 +381,14 @@ final class TimerState {
         windupPlayer?.stop()
 
         if isWinding {
-            frozenSliderOffset = windingSliderOffset(at: Date())
+            frozenSliderOffset = windingSliderOffset(at: scheduler.now)
             cancelWind()
         } else {
-            frozenSliderOffset = continuousSliderOffset(at: Date())
+            frozenSliderOffset = continuousSliderOffset(at: scheduler.now)
         }
 
-        timer?.invalidate()
-        timer = nil
+        timerTask?.cancel()
+        timerTask = nil
         pausedMode = mode == .stopped ? .working : mode
         mode = .stopped
         remainingSeconds = 0
@@ -351,7 +414,7 @@ final class TimerState {
         let exactSeconds = Double(frozenSliderOffset) / Double(Self.pointsPerMinute) * 60.0
         mode = pausedMode
         cycleDuration = exactSeconds
-        cycleStartDate = Date()
+        cycleStartDate = scheduler.now
         remainingSeconds = Int(ceil(exactSeconds))
         startTimer()
     }
@@ -369,20 +432,18 @@ final class TimerState {
         windFromOffset = from
         windToOffset = target
         windDuration = duration
-        windStartDate = Date()
+        windStartDate = scheduler.now
 
-        windCheckTimer?.invalidate()
-        windCheckTimer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { _ in
-            Task { @MainActor in
-                completion()
-            }
+        windCheckTask?.cancel()
+        windCheckTask = scheduler.schedule(after: duration) {
+            completion()
         }
     }
 
     private func cancelWind() {
         isWinding = false
-        windCheckTimer?.invalidate()
-        windCheckTimer = nil
+        windCheckTask?.cancel()
+        windCheckTask = nil
     }
 
     private func finishWindAndBeginCycle(_ newMode: TimerMode) {
@@ -392,17 +453,15 @@ final class TimerState {
     }
 
     private func startTimer() {
-        timer?.invalidate()
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.tick()
-            }
+        timerTask?.cancel()
+        timerTask = scheduler.scheduleRepeating(every: 1.0) { [weak self] in
+            self?.tick()
         }
     }
 
     private func tick() {
         guard let startDate = cycleStartDate else { return }
-        let elapsed = Date().timeIntervalSince(startDate)
+        let elapsed = scheduler.now.timeIntervalSince(startDate)
         let remaining = Int(ceil(cycleDuration - elapsed))
 
         if remaining <= 0 {
@@ -414,8 +473,8 @@ final class TimerState {
     }
 
     private func cycleComplete() {
-        timer?.invalidate()
-        timer = nil
+        timerTask?.cancel()
+        timerTask = nil
         cycleStartDate = nil
         cycleDuration = 0
         playSound(dingSound)
@@ -425,7 +484,7 @@ final class TimerState {
         let nextMinutes = minutes(for: nextMode)
         let targetOffset = CGFloat(nextMinutes) * Self.pointsPerMinute
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+        scheduler.schedule(after: 2.0) { [weak self] in
             guard let self else { return }
             self.mode = nextMode
             self.beginWindAnimation(from: 0, to: targetOffset, clickCount: max(nextMinutes, 1)) { [weak self] in
@@ -438,7 +497,7 @@ final class TimerState {
         let minutes = minutes(for: newMode)
         mode = newMode
         cycleDuration = TimeInterval(minutes * 60)
-        cycleStartDate = Date()
+        cycleStartDate = scheduler.now
         remainingSeconds = minutes * 60
         frozenSliderOffset = 0
         startTimer()

--- a/Mater/Model/TimerState.swift
+++ b/Mater/Model/TimerState.swift
@@ -97,6 +97,7 @@ final class TimerState {
 
     private var timerTask: TimerStateScheduledTask?
     private var windCheckTask: TimerStateScheduledTask?
+    private var pendingCycleTransitionTask: TimerStateScheduledTask?
     private var windupPlayer: AVAudioPlayer?
 
     private let dingSound: NSSound?
@@ -244,6 +245,8 @@ final class TimerState {
     }
 
     func dragBegan() {
+        cancelPendingCycleTransition()
+
         if isMomentum {
             isMomentum = false
             momentumLastUpdate = nil
@@ -368,6 +371,8 @@ final class TimerState {
     }
 
     func start() {
+        cancelPendingCycleTransition()
+
         let targetOffset = maxWorkOffset
         let distance = abs(targetOffset - frozenSliderOffset)
         let clickCount = max(Int(round(distance / Self.pointsPerMinute)), 1)
@@ -377,6 +382,7 @@ final class TimerState {
     }
 
     func stop() {
+        cancelPendingCycleTransition()
         playSound(toggleOffSound)
         windupPlayer?.stop()
 
@@ -409,6 +415,7 @@ final class TimerState {
     }
 
     func resume() {
+        cancelPendingCycleTransition()
         guard frozenSliderOffset >= Self.pointsPerMinute else { return }
         playSound(toggleOnSound)
         let exactSeconds = Double(frozenSliderOffset) / Double(Self.pointsPerMinute) * 60.0
@@ -459,6 +466,11 @@ final class TimerState {
         }
     }
 
+    private func cancelPendingCycleTransition() {
+        pendingCycleTransitionTask?.cancel()
+        pendingCycleTransitionTask = nil
+    }
+
     private func tick() {
         guard let startDate = cycleStartDate else { return }
         let elapsed = scheduler.now.timeIntervalSince(startDate)
@@ -473,6 +485,7 @@ final class TimerState {
     }
 
     private func cycleComplete() {
+        cancelPendingCycleTransition()
         timerTask?.cancel()
         timerTask = nil
         cycleStartDate = nil
@@ -484,8 +497,9 @@ final class TimerState {
         let nextMinutes = minutes(for: nextMode)
         let targetOffset = CGFloat(nextMinutes) * Self.pointsPerMinute
 
-        scheduler.schedule(after: 2.0) { [weak self] in
+        pendingCycleTransitionTask = scheduler.schedule(after: 2.0) { [weak self] in
             guard let self else { return }
+            self.pendingCycleTransitionTask = nil
             self.mode = nextMode
             self.beginWindAnimation(from: 0, to: targetOffset, clickCount: max(nextMinutes, 1)) { [weak self] in
                 self?.finishWindAndBeginCycle(nextMode)

--- a/MaterTests/TimerStateTests.swift
+++ b/MaterTests/TimerStateTests.swift
@@ -8,11 +8,60 @@ private func makePrefs() -> AppPreferences {
 }
 
 @MainActor
-private func makeTimerState(workMinutes: Int = 25, breakMinutes: Int = 5) -> TimerState {
+private final class ManualScheduledTask: TimerStateScheduledTask {
+    let interval: TimeInterval
+    let action: @MainActor () -> Void
+    private(set) var isCancelled = false
+
+    init(interval: TimeInterval, action: @escaping @MainActor () -> Void) {
+        self.interval = interval
+        self.action = action
+    }
+
+    func cancel() {
+        isCancelled = true
+    }
+
+    func fire() {
+        guard !isCancelled else { return }
+        action()
+    }
+}
+
+@MainActor
+private final class ManualTimerStateScheduler: TimerStateScheduling {
+    var now = Date(timeIntervalSince1970: 1_000)
+    private(set) var delayedTasks: [ManualScheduledTask] = []
+    private(set) var repeatingTasks: [ManualScheduledTask] = []
+
+    func schedule(after interval: TimeInterval, _ action: @escaping @MainActor () -> Void) -> TimerStateScheduledTask {
+        let task = ManualScheduledTask(interval: interval, action: action)
+        delayedTasks.append(task)
+        return task
+    }
+
+    func scheduleRepeating(every interval: TimeInterval, _ action: @escaping @MainActor () -> Void) -> TimerStateScheduledTask {
+        let task = ManualScheduledTask(interval: interval, action: action)
+        repeatingTasks.append(task)
+        return task
+    }
+}
+
+@MainActor
+private func makeTimerState(
+    workMinutes: Int = 25,
+    breakMinutes: Int = 5,
+    scheduler: TimerStateScheduling? = nil
+) -> TimerState {
     let prefs = makePrefs()
     prefs.workMinutes = workMinutes
     prefs.breakMinutes = breakMinutes
-    let state = TimerState(preferences: prefs)
+    let state: TimerState
+    if let scheduler {
+        state = TimerState(preferences: prefs, scheduler: scheduler)
+    } else {
+        state = TimerState(preferences: prefs)
+    }
     state.soundEnabled = false
     return state
 }
@@ -169,7 +218,63 @@ private func startCycleViaDrag(_ state: TimerState, minutes: Int = 25) {
         #expect(state.soundEnabled == false)
         #expect(prefs.soundEnabled == false)
     }
+}
 
+// MARK: - Timer Scheduling
+
+@MainActor
+@Suite struct TimerSchedulingTests {
+    @Test func repeatingTickUpdatesRemainingTimeWithoutSleeping() {
+        let scheduler = ManualTimerStateScheduler()
+        let state = makeTimerState(scheduler: scheduler)
+
+        startCycleViaDrag(state)
+        #expect(scheduler.repeatingTasks.count == 1)
+
+        scheduler.now = scheduler.now.addingTimeInterval(61)
+        scheduler.repeatingTasks[0].fire()
+
+        #expect(state.remainingSeconds == 1439)
+        state.stop()
+    }
+
+    @Test func cycleCompletionSchedulesDelayedNextCycleWindup() {
+        let scheduler = ManualTimerStateScheduler()
+        let state = makeTimerState(workMinutes: 1, breakMinutes: 1, scheduler: scheduler)
+
+        startCycleViaDrag(state, minutes: 1)
+        scheduler.now = scheduler.now.addingTimeInterval(60)
+        scheduler.repeatingTasks[0].fire()
+
+        #expect(state.remainingSeconds == 0)
+        #expect(state.cycleStartDate == nil)
+        #expect(scheduler.delayedTasks.count == 1)
+        #expect(scheduler.delayedTasks[0].interval == 2.0)
+
+        scheduler.delayedTasks[0].fire()
+
+        #expect(state.mode == .breaking)
+        #expect(state.isWinding == true)
+        state.stop()
+    }
+
+    @Test func windCompletionCanBeFiredDeterministically() {
+        let scheduler = ManualTimerStateScheduler()
+        let state = makeTimerState(scheduler: scheduler)
+
+        state.start()
+
+        #expect(state.isWinding == true)
+        #expect(scheduler.delayedTasks.count == 1)
+        #expect(scheduler.delayedTasks[0].interval == state.windDuration)
+
+        scheduler.delayedTasks[0].fire()
+
+        #expect(state.isWinding == false)
+        #expect(state.mode == .working)
+        #expect(state.cycleStartDate == scheduler.now)
+        state.stop()
+    }
 }
 
 // MARK: - Toggle and Resume

--- a/MaterTests/TimerStateTests.swift
+++ b/MaterTests/TimerStateTests.swift
@@ -275,6 +275,61 @@ private func startCycleViaDrag(_ state: TimerState, minutes: Int = 25) {
         #expect(state.cycleStartDate == scheduler.now)
         state.stop()
     }
+
+    @Test func stoppingDuringCompletionDelayPreventsNextCycle() {
+        let scheduler = ManualTimerStateScheduler()
+        let state = makeTimerState(workMinutes: 1, breakMinutes: 1, scheduler: scheduler)
+        let transition = completeOneMinuteCycle(state, scheduler: scheduler)
+
+        state.stop()
+        transition.fire()
+
+        #expect(state.mode == .stopped)
+        #expect(state.isWinding == false)
+        #expect(state.cycleStartDate == nil)
+        #expect(state.remainingSeconds == 0)
+    }
+
+    @Test func draggingDuringCompletionDelayPreventsQueuedNextCycle() {
+        let scheduler = ManualTimerStateScheduler()
+        let state = makeTimerState(workMinutes: 3, breakMinutes: 1, scheduler: scheduler)
+        let transition = completeOneMinuteCycle(state, scheduler: scheduler)
+
+        state.dragBegan()
+        state.dragChanged(offset: TimerState.pointsPerMinute * 3)
+        state.dragEnded(velocity: 0)
+        transition.fire()
+
+        #expect(state.mode == .working)
+        #expect(state.remainingSeconds == 180)
+        #expect(state.isWinding == false)
+        state.stop()
+    }
+
+    @Test func normalDelayedTransitionStillWorks() {
+        let scheduler = ManualTimerStateScheduler()
+        let state = makeTimerState(workMinutes: 1, breakMinutes: 1, scheduler: scheduler)
+        let transition = completeOneMinuteCycle(state, scheduler: scheduler)
+
+        transition.fire()
+
+        #expect(state.mode == .breaking)
+        #expect(state.isWinding == true)
+        state.stop()
+    }
+
+    private func completeOneMinuteCycle(
+        _ state: TimerState,
+        scheduler: ManualTimerStateScheduler
+    ) -> ManualScheduledTask {
+        startCycleViaDrag(state, minutes: 1)
+        scheduler.now = scheduler.now.addingTimeInterval(60)
+        scheduler.repeatingTasks[0].fire()
+
+        #expect(state.remainingSeconds == 0)
+        #expect(scheduler.delayedTasks.count == 1)
+        return scheduler.delayedTasks[0]
+    }
 }
 
 // MARK: - Toggle and Resume


### PR DESCRIPTION
## Summary
- Add injected clock/scheduler seams for `TimerState` timers and delayed work.
- Use scheduler time for `TimerState`-owned state transitions.
- Add manual-scheduler tests for ticks, cycle completion, and wind completion.
- Includes the merged #411 pending-transition cancellation branch.

## Tests
- `xcodebuild test -project Mater.xcodeproj -scheme Mater -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/mater-derived-plan001`
- #411 additionally passed `xcodebuild test -project Mater.xcodeproj -scheme Mater -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/mater-derived-plan002`
