### PR TITLE
Cancel pending cycle transition

### DIFF
--- a/Mater/Model/TimerState.swift
+++ b/Mater/Model/TimerState.swift
@@ -97,6 +97,7 @@ final class TimerState {
 
     private var timerTask: TimerStateScheduledTask?
     private var windCheckTask: TimerStateScheduledTask?
+    private var pendingCycleTransitionTask: TimerStateScheduledTask?
     private var windupPlayer: AVAudioPlayer?
 
     private let dingSound: NSSound?
@@ -244,6 +245,8 @@ final class TimerState {
     }
 
     func dragBegan() {
+        cancelPendingCycleTransition()
+
         if isMomentum {
             isMomentum = false
             momentumLastUpdate = nil
@@ -368,6 +371,8 @@ final class TimerState {
     }
 
     func start() {
+        cancelPendingCycleTransition()
+
         let targetOffset = maxWorkOffset
         let distance = abs(targetOffset - frozenSliderOffset)
         let clickCount = max(Int(round(distance / Self.pointsPerMinute)), 1)
@@ -377,6 +382,7 @@ final class TimerState {
     }
 
     func stop() {
+        cancelPendingCycleTransition()
         playSound(toggleOffSound)
         windupPlayer?.stop()
 
@@ -409,6 +415,7 @@ final class TimerState {
     }
 
     func resume() {
+        cancelPendingCycleTransition()
         guard frozenSliderOffset >= Self.pointsPerMinute else { return }
         playSound(toggleOnSound)
         let exactSeconds = Double(frozenSliderOffset) / Double(Self.pointsPerMinute) * 60.0
@@ -459,6 +466,11 @@ final class TimerState {
         }
     }
 
+    private func cancelPendingCycleTransition() {
+        pendingCycleTransitionTask?.cancel()
+        pendingCycleTransitionTask = nil
+    }
+
     private func tick() {
         guard let startDate = cycleStartDate else { return }
         let elapsed = scheduler.now.timeIntervalSince(startDate)
@@ -473,6 +485,7 @@ final class TimerState {
     }
 
     private func cycleComplete() {
+        cancelPendingCycleTransition()
         timerTask?.cancel()
         timerTask = nil
         cycleStartDate = nil
@@ -484,8 +497,9 @@ final class TimerState {
         let nextMinutes = minutes(for: nextMode)
         let targetOffset = CGFloat(nextMinutes) * Self.pointsPerMinute
 
-        scheduler.schedule(after: 2.0) { [weak self] in
+        pendingCycleTransitionTask = scheduler.schedule(after: 2.0) { [weak self] in
             guard let self else { return }
+            self.pendingCycleTransitionTask = nil
             self.mode = nextMode
             self.beginWindAnimation(from: 0, to: targetOffset, clickCount: max(nextMinutes, 1)) { [weak self] in
                 self?.finishWindAndBeginCycle(nextMode)

--- a/MaterTests/TimerStateTests.swift
+++ b/MaterTests/TimerStateTests.swift
@@ -275,6 +275,61 @@ private func startCycleViaDrag(_ state: TimerState, minutes: Int = 25) {
         #expect(state.cycleStartDate == scheduler.now)
         state.stop()
     }
+
+    @Test func stoppingDuringCompletionDelayPreventsNextCycle() {
+        let scheduler = ManualTimerStateScheduler()
+        let state = makeTimerState(workMinutes: 1, breakMinutes: 1, scheduler: scheduler)
+        let transition = completeOneMinuteCycle(state, scheduler: scheduler)
+
+        state.stop()
+        transition.fire()
+
+        #expect(state.mode == .stopped)
+        #expect(state.isWinding == false)
+        #expect(state.cycleStartDate == nil)
+        #expect(state.remainingSeconds == 0)
+    }
+
+    @Test func draggingDuringCompletionDelayPreventsQueuedNextCycle() {
+        let scheduler = ManualTimerStateScheduler()
+        let state = makeTimerState(workMinutes: 3, breakMinutes: 1, scheduler: scheduler)
+        let transition = completeOneMinuteCycle(state, scheduler: scheduler)
+
+        state.dragBegan()
+        state.dragChanged(offset: TimerState.pointsPerMinute * 3)
+        state.dragEnded(velocity: 0)
+        transition.fire()
+
+        #expect(state.mode == .working)
+        #expect(state.remainingSeconds == 180)
+        #expect(state.isWinding == false)
+        state.stop()
+    }
+
+    @Test func normalDelayedTransitionStillWorks() {
+        let scheduler = ManualTimerStateScheduler()
+        let state = makeTimerState(workMinutes: 1, breakMinutes: 1, scheduler: scheduler)
+        let transition = completeOneMinuteCycle(state, scheduler: scheduler)
+
+        transition.fire()
+
+        #expect(state.mode == .breaking)
+        #expect(state.isWinding == true)
+        state.stop()
+    }
+
+    private func completeOneMinuteCycle(
+        _ state: TimerState,
+        scheduler: ManualTimerStateScheduler
+    ) -> ManualScheduledTask {
+        startCycleViaDrag(state, minutes: 1)
+        scheduler.now = scheduler.now.addingTimeInterval(60)
+        scheduler.repeatingTasks[0].fire()
+
+        #expect(state.remainingSeconds == 0)
+        #expect(scheduler.delayedTasks.count == 1)
+        return scheduler.delayedTasks[0]
+    }
 }
 
 // MARK: - Toggle and Resume


### PR DESCRIPTION
## Summary
- Track the delayed next-cycle transition scheduled after completion.
- Cancel stale transition work from stop, drag, start, and resume paths.
- Add deterministic regression tests for stop, drag, and normal delayed transition behavior.

## Tests
- `xcodebuild test -project Mater.xcodeproj -scheme Mater -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/mater-derived-plan002`

Stacked on #410.
