### PR TITLE
Cancel stale windup audio

### DIFF
--- a/Mater/Model/TimerState.swift
+++ b/Mater/Model/TimerState.swift
@@ -65,6 +65,8 @@ final class SystemTimerStateScheduler: TimerStateScheduling {
     }
 }
 
+typealias WindupPlayerFactory = @Sendable (_ clickCount: Int, _ duration: TimeInterval) async -> AVAudioPlayer?
+
 @MainActor @Observable
 final class TimerState {
     static let pointsPerMinute: CGFloat = 20
@@ -73,7 +75,12 @@ final class TimerState {
     private(set) var remainingSeconds: Int = 0
     var soundEnabled: Bool {
         get { preferences.soundEnabled }
-        set { preferences.soundEnabled = newValue }
+        set {
+            preferences.soundEnabled = newValue
+            if !newValue {
+                cancelWindupAudio()
+            }
+        }
     }
     var onCycleComplete: (() -> Void)?
 
@@ -97,7 +104,9 @@ final class TimerState {
 
     private var timerTask: TimerStateScheduledTask?
     private var windCheckTask: TimerStateScheduledTask?
-    private var windupPlayer: AVAudioPlayer?
+    private var windupTask: Task<Void, Never>?
+    private var windupGeneration = 0
+    private(set) var windupPlayer: AVAudioPlayer?
 
     private let dingSound: NSSound?
     private let toggleOnSound: NSSound?
@@ -106,6 +115,7 @@ final class TimerState {
 
     let preferences: AppPreferences
     private let scheduler: TimerStateScheduling
+    private let makeWindupPlayer: WindupPlayerFactory
     private var workMinutes: Int { preferences.workMinutes }
     private var breakMinutes: Int { preferences.breakMinutes }
     private static let windSpeed: CGFloat = 500
@@ -119,9 +129,24 @@ final class TimerState {
         self.init(preferences: preferences, scheduler: SystemTimerStateScheduler())
     }
 
-    init(preferences: AppPreferences, scheduler: TimerStateScheduling) {
+    convenience init(preferences: AppPreferences, scheduler: TimerStateScheduling) {
+        self.init(
+            preferences: preferences,
+            scheduler: scheduler,
+            makeWindupPlayer: { clickCount, duration in
+                WindupSoundGenerator.generate(clickCount: clickCount, totalDuration: duration)
+            }
+        )
+    }
+
+    init(
+        preferences: AppPreferences,
+        scheduler: TimerStateScheduling,
+        makeWindupPlayer: @escaping WindupPlayerFactory
+    ) {
         self.preferences = preferences
         self.scheduler = scheduler
+        self.makeWindupPlayer = makeWindupPlayer
         dingSound = Self.loadSound("ding")
         toggleOnSound = Self.loadSound("toggle_on")
         toggleOffSound = Self.loadSound("toggle_off")
@@ -256,7 +281,7 @@ final class TimerState {
 
         timerTask?.cancel()
         timerTask = nil
-        windupPlayer?.stop()
+        cancelWindupAudio()
         cycleStartDate = nil
         cycleDuration = 0
 
@@ -378,7 +403,7 @@ final class TimerState {
 
     func stop() {
         playSound(toggleOffSound)
-        windupPlayer?.stop()
+        cancelWindupAudio()
 
         if isWinding {
             frozenSliderOffset = windingSliderOffset(at: scheduler.now)
@@ -446,6 +471,14 @@ final class TimerState {
         windCheckTask = nil
     }
 
+    private func cancelWindupAudio() {
+        windupGeneration += 1
+        windupTask?.cancel()
+        windupTask = nil
+        windupPlayer?.stop()
+        windupPlayer = nil
+    }
+
     private func finishWindAndBeginCycle(_ newMode: TimerMode) {
         isWinding = false
         windStartDate = nil
@@ -504,14 +537,25 @@ final class TimerState {
     }
 
     private func playWindup(clickCount: Int, duration: TimeInterval) {
+        cancelWindupAudio()
         guard soundEnabled else { return }
-        windupPlayer?.stop()
-        windupPlayer = nil
-        Task.detached(priority: .userInitiated) {
-            let player = WindupSoundGenerator.generate(clickCount: clickCount, totalDuration: duration)
+
+        let generation = windupGeneration
+        let factory = makeWindupPlayer
+        windupTask = Task.detached(priority: .userInitiated) { [weak self] in
+            let player = await factory(clickCount, duration)
+            guard !Task.isCancelled else { return }
+
             await MainActor.run { [weak self] in
-                self?.windupPlayer = player
-                self?.windupPlayer?.play()
+                guard let self,
+                      !Task.isCancelled,
+                      self.windupGeneration == generation,
+                      self.soundEnabled
+                else { return }
+
+                self.windupPlayer = player
+                self.windupPlayer?.play()
+                self.windupTask = nil
             }
         }
     }

--- a/Mater/Model/TimerState.swift
+++ b/Mater/Model/TimerState.swift
@@ -158,9 +158,9 @@ final class TimerState {
     }
 
     private func prewarmAudio() {
-        // Force tick sample loading off the main thread
+        // Force tick sample and Core Audio setup off the main thread.
         Task.detached(priority: .userInitiated) {
-            WindupSoundGenerator.warmUp()
+            WindupSoundGenerator.warmUpPlayback()
         }
     }
 

--- a/Mater/Model/WindupSoundGenerator.swift
+++ b/Mater/Model/WindupSoundGenerator.swift
@@ -8,6 +8,13 @@ struct WindupSoundGenerator {
         _ = cachedTickSamples
     }
 
+    /// Prepare a tiny player so the first visible wind-up does not pay Core Audio setup costs.
+    static func warmUpPlayback() {
+        warmUp()
+        let player = generate(clickCount: 1, totalDuration: 0.25)
+        player?.prepareToPlay()
+    }
+
     static func generate(clickCount: Int, totalDuration: TimeInterval) -> AVAudioPlayer? {
         guard clickCount > 0, totalDuration > 0 else { return nil }
         guard let tickSamples = cachedTickSamples else { return nil }

--- a/Mater/Panel/StatusItemController.swift
+++ b/Mater/Panel/StatusItemController.swift
@@ -21,11 +21,12 @@ final class StatusItemController: NSObject {
         super.init()
 
         if let button = statusItem.button {
-            button.image = Self.makeIcon(named: "icon-stopped")
+            button.image = cachedIcon(named: "icon-stopped")
             button.action = #selector(handleClick)
             button.target = self
             button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
+        prewarmLikelyIcons()
 
         timerState.onCycleComplete = { [weak self] in
             self?.showPanel()
@@ -113,12 +114,22 @@ final class StatusItemController: NSObject {
         let name = timerState.iconName
         guard name != lastIconName else { return }
         lastIconName = name
+        button.image = cachedIcon(named: name)
+    }
+
+    private func prewarmLikelyIcons() {
+        _ = cachedIcon(named: "icon-\(timerState.preferences.workMinutes)")
+        _ = cachedIcon(named: "icon-\(timerState.preferences.breakMinutes)-break")
+    }
+
+    private func cachedIcon(named name: String) -> NSImage? {
         if let cached = iconCache[name] {
-            button.image = cached
-        } else if let icon = Self.makeIcon(named: name) {
-            iconCache[name] = icon
-            button.image = icon
+            return cached
         }
+        guard let icon = Self.makeIcon(named: name) else { return nil }
+        Self.forceRender(icon)
+        iconCache[name] = icon
+        return icon
     }
 
     private func setupOutsideClickMonitors() {
@@ -169,6 +180,11 @@ final class StatusItemController: NSObject {
         }
         let minute = name.replacingOccurrences(of: "icon-", with: "")
         return IconGenerator.generate(text: minute, style: .filled)
+    }
+
+    private static func forceRender(_ image: NSImage) {
+        var proposedRect = NSRect(origin: .zero, size: image.size)
+        _ = image.cgImage(forProposedRect: &proposedRect, context: nil, hints: nil)
     }
 
     static func panelOrigin(buttonRect: CGRect, panelSize: CGSize) -> CGPoint {

--- a/MaterTests/TimerStateTests.swift
+++ b/MaterTests/TimerStateTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import AppKit
+import AVFoundation
 @testable import Mater
 
 @MainActor
@@ -48,17 +49,83 @@ private final class ManualTimerStateScheduler: TimerStateScheduling {
 }
 
 @MainActor
+private final class AsyncGate: @unchecked Sendable {
+    private var isOpen = false
+    private var hasWaiter = false
+    private var waitContinuation: CheckedContinuation<Void, Never>?
+    private var waiterContinuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        hasWaiter = true
+        waiterContinuation?.resume()
+        waiterContinuation = nil
+
+        if isOpen { return }
+
+        await withCheckedContinuation { continuation in
+            if isOpen {
+                continuation.resume()
+            } else {
+                waitContinuation = continuation
+            }
+        }
+    }
+
+    func waitForWaiter() async {
+        if hasWaiter || isOpen { return }
+
+        await withCheckedContinuation { continuation in
+            waiterContinuation = continuation
+        }
+    }
+
+    func open() {
+        isOpen = true
+        waitContinuation?.resume()
+        waitContinuation = nil
+        waiterContinuation?.resume()
+        waiterContinuation = nil
+    }
+}
+
+@MainActor
+private final class GatedWindupPlayerFactory: @unchecked Sendable {
+    private let gates: [AsyncGate]
+    private var nextGateIndex = 0
+
+    init(_ gates: [AsyncGate]) {
+        self.gates = gates
+    }
+
+    func makePlayer(clickCount _: Int, duration _: TimeInterval) async -> AVAudioPlayer? {
+        let gate = gates[min(nextGateIndex, gates.count - 1)]
+        nextGateIndex += 1
+        await gate.wait()
+        return WindupSoundGenerator.generate(clickCount: 1, totalDuration: 0.05)
+    }
+}
+
+@MainActor
 private func makeTimerState(
     workMinutes: Int = 25,
     breakMinutes: Int = 5,
-    scheduler: TimerStateScheduling? = nil
+    scheduler: TimerStateScheduling? = nil,
+    makeWindupPlayer: WindupPlayerFactory? = nil
 ) -> TimerState {
     let prefs = makePrefs()
     prefs.workMinutes = workMinutes
     prefs.breakMinutes = breakMinutes
     let state: TimerState
-    if let scheduler {
+    if let scheduler, let makeWindupPlayer {
+        state = TimerState(preferences: prefs, scheduler: scheduler, makeWindupPlayer: makeWindupPlayer)
+    } else if let scheduler {
         state = TimerState(preferences: prefs, scheduler: scheduler)
+    } else if let makeWindupPlayer {
+        state = TimerState(
+            preferences: prefs,
+            scheduler: SystemTimerStateScheduler(),
+            makeWindupPlayer: makeWindupPlayer
+        )
     } else {
         state = TimerState(preferences: prefs)
     }
@@ -274,6 +341,89 @@ private func startCycleViaDrag(_ state: TimerState, minutes: Int = 25) {
         #expect(state.mode == .working)
         #expect(state.cycleStartDate == scheduler.now)
         state.stop()
+    }
+}
+
+// MARK: - Windup Audio Cancellation
+
+@MainActor
+@Suite struct WindupAudioCancellationTests {
+    @Test func stoppingBeforeWindupAudioFinishesPreventsPlayerInstall() async {
+        let scheduler = ManualTimerStateScheduler()
+        let gate = AsyncGate()
+        let factory = GatedWindupPlayerFactory([gate])
+        let state = makeTimerState(
+            scheduler: scheduler,
+            makeWindupPlayer: { clickCount, duration in
+                await factory.makePlayer(clickCount: clickCount, duration: duration)
+            }
+        )
+        state.soundEnabled = true
+
+        state.start()
+        await gate.waitForWaiter()
+        state.stop()
+        gate.open()
+        await yieldToWindupTasks()
+
+        #expect(state.windupPlayer == nil)
+        #expect(state.isWinding == false)
+    }
+
+    @Test func disablingSoundBeforeWindupAudioFinishesPreventsPlayerInstall() async {
+        let scheduler = ManualTimerStateScheduler()
+        let gate = AsyncGate()
+        let factory = GatedWindupPlayerFactory([gate])
+        let state = makeTimerState(
+            scheduler: scheduler,
+            makeWindupPlayer: { clickCount, duration in
+                await factory.makePlayer(clickCount: clickCount, duration: duration)
+            }
+        )
+        state.soundEnabled = true
+
+        state.start()
+        await gate.waitForWaiter()
+        state.soundEnabled = false
+        gate.open()
+        await yieldToWindupTasks()
+
+        #expect(state.windupPlayer == nil)
+        state.stop()
+    }
+
+    @Test func supersededWindupIgnoresFirstLateResult() async {
+        let scheduler = ManualTimerStateScheduler()
+        let firstGate = AsyncGate()
+        let secondGate = AsyncGate()
+        let factory = GatedWindupPlayerFactory([firstGate, secondGate])
+        let state = makeTimerState(
+            scheduler: scheduler,
+            makeWindupPlayer: { clickCount, duration in
+                await factory.makePlayer(clickCount: clickCount, duration: duration)
+            }
+        )
+        state.soundEnabled = true
+
+        state.start()
+        await firstGate.waitForWaiter()
+        state.start()
+        await secondGate.waitForWaiter()
+
+        firstGate.open()
+        await yieldToWindupTasks()
+        #expect(state.windupPlayer == nil)
+
+        secondGate.open()
+        await yieldToWindupTasks()
+        #expect(state.windupPlayer != nil)
+        state.stop()
+    }
+
+    private func yieldToWindupTasks() async {
+        for _ in 0..<50 {
+            await Task.yield()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Inject windup audio generation for deterministic cancellation tests.
- Track and cancel windup audio tasks with generation checks before installing players.
- Cover stop, sound disable, and superseded windup races.
- Prewarm first-start audio and likely status icons to reduce initial Start lag.

## Tests
- `xcodebuild test -project Mater.xcodeproj -scheme Mater -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/mater-derived-plan003-prewarm`

Stacked on #410; includes the merged #411 transition-cancellation branch.
