### PR TITLE
Clamp persisted timer durations

### DIFF
--- a/Mater/Model/AppPreferences.swift
+++ b/Mater/Model/AppPreferences.swift
@@ -8,14 +8,29 @@ final class AppPreferences {
     private static let breakKey = "AppPreferences.breakMinutes"
     private static let soundKey = "AppPreferences.soundEnabled"
 
+    static let workRange = 1...60
+    static let breakRange = 1...30
+    private static let defaultWorkMinutes = 25
+    private static let defaultBreakMinutes = 5
+
     private let defaults: UserDefaults
+    private var storedWorkMinutes: Int
+    private var storedBreakMinutes: Int
 
     var workMinutes: Int {
-        didSet { defaults.set(workMinutes, forKey: Self.workKey) }
+        get { storedWorkMinutes }
+        set {
+            storedWorkMinutes = Self.clamped(newValue, to: Self.workRange)
+            defaults.set(storedWorkMinutes, forKey: Self.workKey)
+        }
     }
 
     var breakMinutes: Int {
-        didSet { defaults.set(breakMinutes, forKey: Self.breakKey) }
+        get { storedBreakMinutes }
+        set {
+            storedBreakMinutes = Self.clamped(newValue, to: Self.breakRange)
+            defaults.set(storedBreakMinutes, forKey: Self.breakKey)
+        }
     }
 
     var soundEnabled: Bool {
@@ -33,10 +48,32 @@ final class AppPreferences {
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        let storedWork = defaults.integer(forKey: Self.workKey)
-        let storedBreak = defaults.integer(forKey: Self.breakKey)
-        self.workMinutes = storedWork > 0 ? storedWork : 25
-        self.breakMinutes = storedBreak > 0 ? storedBreak : 5
-        self.soundEnabled = defaults.object(forKey: Self.soundKey) as? Bool ?? true
+        storedWorkMinutes = Self.storedMinutes(
+            defaults: defaults,
+            key: Self.workKey,
+            defaultValue: Self.defaultWorkMinutes,
+            range: Self.workRange
+        )
+        storedBreakMinutes = Self.storedMinutes(
+            defaults: defaults,
+            key: Self.breakKey,
+            defaultValue: Self.defaultBreakMinutes,
+            range: Self.breakRange
+        )
+        soundEnabled = defaults.object(forKey: Self.soundKey) as? Bool ?? true
+    }
+
+    private static func clamped(_ value: Int, to range: ClosedRange<Int>) -> Int {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+
+    private static func storedMinutes(
+        defaults: UserDefaults,
+        key: String,
+        defaultValue: Int,
+        range: ClosedRange<Int>
+    ) -> Int {
+        guard let value = defaults.object(forKey: key) as? Int else { return defaultValue }
+        return clamped(value, to: range)
     }
 }

--- a/Mater/Views/SettingsView.swift
+++ b/Mater/Views/SettingsView.swift
@@ -111,20 +111,17 @@ private struct SettingsTabButtonStyle: ButtonStyle {
 private struct GeneralSettingsPane: View {
     @Bindable var preferences: AppPreferences
 
-    private let workRange = 1...60
-    private let breakRange = 1...30
-
     var body: some View {
         Form {
             Section("Timer") {
                 Picker("Work duration", selection: $preferences.workMinutes) {
-                    ForEach(Array(workRange), id: \.self) { min in
+                    ForEach(Array(AppPreferences.workRange), id: \.self) { min in
                         Text("\(min) min").tag(min)
                     }
                 }
 
                 Picker("Break duration", selection: $preferences.breakMinutes) {
-                    ForEach(Array(breakRange), id: \.self) { min in
+                    ForEach(Array(AppPreferences.breakRange), id: \.self) { min in
                         Text("\(min) min").tag(min)
                     }
                 }

--- a/MaterTests/TimerStateTests.swift
+++ b/MaterTests/TimerStateTests.swift
@@ -2,6 +2,9 @@ import Testing
 import AppKit
 @testable import Mater
 
+private let workMinutesPreferenceKey = "AppPreferences.workMinutes"
+private let breakMinutesPreferenceKey = "AppPreferences.breakMinutes"
+
 @MainActor
 private func makePrefs() -> AppPreferences {
     AppPreferences(defaults: UserDefaults(suiteName: UUID().uuidString)!)
@@ -57,6 +60,43 @@ private func startCycleViaDrag(_ state: TimerState, minutes: Int = 25) {
         prefs.soundEnabled = false
         let prefs2 = AppPreferences(defaults: defaults)
         #expect(prefs2.soundEnabled == false)
+    }
+
+    @Test func persistedHighDurationsClampToUpperBounds() {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set(999, forKey: workMinutesPreferenceKey)
+        defaults.set(999, forKey: breakMinutesPreferenceKey)
+
+        let prefs = AppPreferences(defaults: defaults)
+
+        #expect(prefs.workMinutes == AppPreferences.workRange.upperBound)
+        #expect(prefs.breakMinutes == AppPreferences.breakRange.upperBound)
+    }
+
+    @Test func persistedLowDurationsClampToLowerBounds() {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set(-10, forKey: workMinutesPreferenceKey)
+        defaults.set(0, forKey: breakMinutesPreferenceKey)
+
+        let prefs = AppPreferences(defaults: defaults)
+
+        #expect(prefs.workMinutes == AppPreferences.workRange.lowerBound)
+        #expect(prefs.breakMinutes == AppPreferences.breakRange.lowerBound)
+    }
+
+    @Test func assignedDurationsClampAndPersist() {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let prefs = AppPreferences(defaults: defaults)
+
+        prefs.workMinutes = 999
+        prefs.breakMinutes = -5
+
+        #expect(prefs.workMinutes == AppPreferences.workRange.upperBound)
+        #expect(prefs.breakMinutes == AppPreferences.breakRange.lowerBound)
+
+        let persistedPrefs = AppPreferences(defaults: defaults)
+        #expect(persistedPrefs.workMinutes == AppPreferences.workRange.upperBound)
+        #expect(persistedPrefs.breakMinutes == AppPreferences.breakRange.lowerBound)
     }
 }
 


### PR DESCRIPTION
## Summary
- Centralize work and break duration ranges in `AppPreferences`.
- Clamp persisted and assigned duration values to supported ranges.
- Update settings pickers and add preference range regression tests.

## Tests
- `xcodebuild test -project Mater.xcodeproj -scheme Mater -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/mater-derived-plan004`
